### PR TITLE
Renames Evenementen to Events

### DIFF
--- a/app/Http/Controllers/EventController.php
+++ b/app/Http/Controllers/EventController.php
@@ -165,7 +165,7 @@ class EventController extends Controller
             'availableSpots' => $availableSpots
         ];
     }
-   public function downloadIcs(Evenementen $event)
+   public function downloadIcs(Events $event)
 {
 
     $startDateTime = Carbon::parse($event->datum . ' ' . $event->starttijd);

--- a/routes/web.php
+++ b/routes/web.php
@@ -28,10 +28,10 @@ Route::get('/', [HomeController::class, 'index'])->name('home');
 
 Route::post('/registration', [RegistrationsController::class, 'store'])->name('registration');
 
-Route::get('/events/create', [EvenementenController::class, 'create'])->name('events.create');
-Route::post('/events/create', [EvenementenController::class, 'store'])->name('events.store');
+Route::get('/events/create', [EventController::class, 'create'])->name('events.create');
+Route::post('/events/create', [EventController::class, 'store'])->name('events.store');
 // routes/web.php
-Route::get('/events/{event}/download-ics', [EvenementenController::class, 'downloadIcs'])->name('events.ics');
+Route::get('/events/{event}/download-ics', [EventController::class, 'downloadIcs'])->name('events.ics');
 
 
 Route::get('/events/index', [EventController::class, 'index'])->name('events.index');

--- a/tests/Browser/EventRegistrationTest.php
+++ b/tests/Browser/EventRegistrationTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Browser;
 
+use Database\Factories\EventsFactory;
 use Illuminate\Foundation\Testing\DatabaseMigrations;
 use Laravel\Dusk\Browser;
 use Tests\DuskTestCase;
@@ -16,7 +17,7 @@ class EventRegistrationTest extends DuskTestCase
     public function link_zet_in_agenda_is_aanwezig_en_werkt()
     {
         // Maak eerst een test-evenement aan in de database
-        $evenement = Evenementen::factory()->create([
+        $evenement = EventsFactory::factory()->create([
             'titel' => 'Test Evenement Dusk',
             'datum' => '2025-03-07',
             'starttijd' => '18:00',
@@ -30,7 +31,7 @@ class EventRegistrationTest extends DuskTestCase
         $this->browse(function (Browser $browser) use ($evenement) {
             $href = route('events.ics', $evenement->id);
 
-            $browser->visit("/evenementen/{$evenement->id}") // Pas URL aan naar je route voor event details
+            $browser->visit("/events/{$evenement->id}") // Pas URL aan naar je route voor event details
                 ->assertSeeLink('Zet in agenda') // Check dat linktekst zichtbaar is
                 ->assertAttribute('a[href="'.$href.'"]', 'href', $href) // Controleer of de link met href aanwezig is
                 ->clickLink('Zet in agenda'); // Klik op de link


### PR DESCRIPTION
Updates all instances of `Evenementen` to `Events`
to align with project naming conventions and improve code readability.
This change impacts controllers, routes, and tests.